### PR TITLE
Fixed pxd file bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
                 "extensions": [
                     ".pyx",
                     ".pyi",
-                    ".pyd"
+                    ".pxd"
                 ],
                 "configuration": "./language-configuration.json"
             }


### PR DESCRIPTION
The extension highlights .pyd file, which are compiled windows binary dll's and not Cython sources. Instead .pxd files should be highlighted.