### PR TITLE
Fix Cython include files extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
                 ],
                 "extensions": [
                     ".pyx",
-                    ".pyi",
+                    ".pxi",
                     ".pxd"
                 ],
                 "configuration": "./language-configuration.json"


### PR DESCRIPTION
Small typo:

- pyi is the extension of the mypy annotation stubs https://www.python.org/dev/peps/pep-0484/
- pxi/pxd are the cython extensions http://docs.cython.org/en/latest/src/userguide/language_basics.html?highlight=pxi#cython-file-types

