### PR TITLE
add auto-intention and some cython highlighting

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -26,5 +26,11 @@
         ["(", ")"],
         ["\"", "\""],
         ["'", "'"]
-    ]
+    ],
+    "onEnterRules": [
+        {
+          "beforeText": "^\\s*(?:def|class|for|if|elif|else|while|try|with|finally|except|async|cdef|cpdef|ctypedef|struct|union|enum|IF|ELIF|ELSE).*?:\\s*$",
+          "action": { "indent": "indent" }
+        }
+      ]
 }

--- a/syntaxes/Cython.tmLanguage
+++ b/syntaxes/Cython.tmLanguage
@@ -407,7 +407,7 @@
             <key>match</key>
             <string>(?x)
   \b(?&lt;!\.)(
-    as | async | continue | del | assert | break | cdef | cpdef | finally | for
+    as | async | continue | del | assert | break | cdef | cpdef | ctypedef | finally | for
     | from | elif | else | if | except | pass | raise
     | return | try | while | with | is | in | not | and | or
   )\b
@@ -2806,11 +2806,13 @@ indirectly through syntactic constructs
         <key>match</key>
         <string>(?x)
   \b(
-    and | as | assert | async | await | break | cdef | cpdef | class | continue | def
+    and | as | assert | async | await | break | cdef | cpdef | ctypedef | class | continue | def
     | del | elif | else | except | exec | finally | for | from | global
     | if | cimport | import | in | is | (?&lt;=\.)lambda | lambda(?=\s*[\.=])
     | nonlocal | not | or | pass | raise | return | try | while | with
-    | yield
+    | yield | (?&lt;=ctypedef\s+)fused | (?&lt;=cp?def\s+)struct | (?&lt;=^\s+)struct(?=.*:)
+    | (?&lt;=cp?def\s+)enum | (?&lt;=^\s+)enum(?=.*:) | (?&lt;=cp?def\s+)union | (?&lt;=^\s+)union(?=.*:)
+    | (?&lt;=cdef\s+)extern | (?&lt;=cdef\s+)api | (?&lt;=cdef\s+public\s+)api | (?&lt;=cdef\s+)public
   )\b
 </string>
       </dict>


### PR DESCRIPTION
- add auto-intention support in language-configuaration.json  
- add syntax highlight for ctypedef( fused), cdef struct/union/enum/extern/public/api.

added highlighting was referenced by: https://cython.readthedocs.io/en/latest/src/userguide/language_basics.html and https://cython.readthedocs.io/en/latest/src/userguide/external_C_code.html#external-c-code